### PR TITLE
feature: apply pnp

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -298,10 +298,17 @@ module.exports = (argv, handlers) => {
     .command({
       command: `new [rootPath] [starter]`,
       desc: `Create new Gatsby project.`,
+      builder: _ =>
+        _.option(`--use-pnp`, {
+          alias: `usePnp`,
+          type: `boolean`,
+          default: false,
+          describe: `Use Plug'n'Play`,
+        }),
       handler: handlerP(
-        ({ rootPath, starter = `gatsbyjs/gatsby-starter-default` }) => {
+        ({ usePnp, rootPath, starter = `gatsbyjs/gatsby-starter-default` }) => {
           const initStarter = require(`./init-starter`)
-          return initStarter(starter, { rootPath })
+          return initStarter(starter, { rootPath }, usePnp)
         }
       ),
     })

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -50,6 +50,8 @@ function checkYarnVersion() {
 }
 
 // Executes `npm install` or `yarn install` in rootPath.
+// Executes --enable-pnp if enabled
+// Tracks installation time
 const install = async (rootPath: string, usePnp: boolean) => {
   const prevDir = process.cwd()
 
@@ -144,6 +146,7 @@ module.exports = async (
   usePnp: boolean
 ) => {
   if (usePnp) {
+    // Used in create-react-app to determine what version of yarn is being used and sets usePnp to false if it's before version 1.12
     if (!shouldUseYarn()) {
       report.warning(`NPM does not support PnP`)
       usePnp = false


### PR DESCRIPTION
This pull request resolves Task 3 in the work samples. 

I enabled the Plug'n'Play feature when a user creates a new Gatsby site. 

New features proposed: 
- Use `--use-pnp` when creating a new Gatsby site (i.e. `gatsby new some-app --use-pnp`)
- When `--use-pnp` is flagged, `node_modules` will not appear

I do show the installation times when it's finished. If I had more time, I would've reached out to someone on the team to fully understand what was wanted from `Installation times should be compared/contrasted via using the flag and not using the flag`. Currently, it just outputs the installation time depending on if it's using PnP or not.

I didn't have enough time to write tests but I did manually test it. If I had more time, I would've written some tests for the functions used and compare if the output is what was expected. 

Basic testing: 
- Run `npm link` in the `gatsby-cli` `node_module`
- Run `npx gatsby new test  --use-pnp` to test PnP
- Run `npx gatsby new test ` to test without PnP
- Check if there are `node_modules` in the new Gatsby site

Note: I referenced `create-react-app` on how to validate if the user is using yarn and if it's the right version as well as the general implementation of PnP.

Let me know if you have any questions!
